### PR TITLE
Fixed issue where windspeed not picked up when not in the wind dict key.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ Code
 ----
   * [liato] (https://github.com/liato)
   * [Noid] (https://github.com/n0id)
+  * [dphildebrandt] (https://github.com/dphildebrandt)
 
 Testing
 -------

--- a/pyowm/webapi25/weather.py
+++ b/pyowm/webapi25/weather.py
@@ -463,6 +463,8 @@ def weather_from_dictionary(d):
     elif 'last' in d:
         if 'wind' in d['last']:
             wind = d['last']['wind'].copy()
+    elif 'speed' in d:
+        wind = dict(speed=d['speed'])
     else:
         wind = dict()
     # -- humidity


### PR DESCRIPTION
A sample file describing the problem I had:
http://api.openweathermap.org/data/2.5/forecast/daily?q=Winnipeg&mode=json&units=metric&cnt=16

You can see the 'speed' key in the JSON with no 'wind'.