### PR TITLE
Detailed status should not be lower()

### DIFF
--- a/pyowm/webapi25/weather.py
+++ b/pyowm/webapi25/weather.py
@@ -526,7 +526,7 @@ def weather_from_dictionary(d):
     if 'weather' in d:
         # Sometimes provided with a leading upper case!
         status = d['weather'][0]['main'].lower()
-        detailed_status = d['weather'][0]['description'].lower()
+        detailed_status = d['weather'][0]['description']
         weather_code = d['weather'][0]['id']
         weather_icon_name = d['weather'][0]['icon']
     else:


### PR DESCRIPTION
Since upper case characters are required in several languages, the detailed status (or description) should not be forced to lower case. lower() should only be applied where needed and in the last possible moment. Otherwise we lose information.

If the casing is not correct on any status, this should be fixed in the translation at OWM's side.