### PR TITLE
Sometimes Wind data is None

### DIFF
--- a/pyowm/webapi25/weather.py
+++ b/pyowm/webapi25/weather.py
@@ -458,7 +458,7 @@ def weather_from_dictionary(d):
     else:
         rain = dict()
     # -- wind
-    if 'wind' in d:
+    if 'wind' in d and d['wind'] is not None:
         wind = d['wind'].copy()
     elif 'last' in d:
         if 'wind' in d['last']:


### PR DESCRIPTION
Hello !
I'm useing Homeassistant, and sometimes I got the following error:
```
Traceback (most recent call last):
  File "/home/titilambert/gits/domo/homeassitant/env/lib/python3.4/site-packages/homeassistant/helpers/entity_component.py", line 98, in _setup_platform
    discovery_info)
  File "/home/titilambert/gits/domo/homeassitant/env/lib/python3.4/site-packages/homeassistant/components/sensor/openweathermap.py", line 70, in setup_platform
    dev.append(OpenWeatherMapSensor(data, variable, unit))
  File "/home/titilambert/gits/domo/homeassitant/env/lib/python3.4/site-packages/homeassistant/components/sensor/openweathermap.py", line 94, in __init__
    self.update()
  File "/home/titilambert/gits/domo/homeassitant/env/lib/python3.4/site-packages/homeassistant/components/sensor/openweathermap.py", line 114, in update
    self.owa_client.update()
  File "/home/titilambert/gits/domo/homeassitant/env/lib/python3.4/site-packages/homeassistant/util/__init__.py", line 289, in wrapper
    result = method(*args, **kwargs)
  File "/home/titilambert/gits/domo/homeassitant/env/lib/python3.4/site-packages/homeassistant/components/sensor/openweathermap.py", line 179, in update
    self.longitude)
  File "/home/titilambert/gits/domo/homeassitant/config/deps/pyowm/webapi25/owm25.py", line 432, in three_hours_forecast_at_coords
    forecast = self._parsers['forecast'].parse_JSON(json_data)
  File "/home/titilambert/gits/domo/homeassitant/config/deps/pyowm/webapi25/forecastparser.py", line 66, in parse_JSON
    for item in d['list']]
  File "/home/titilambert/gits/domo/homeassitant/config/deps/pyowm/webapi25/forecastparser.py", line 66, in <listcomp>
    for item in d['list']]
  File "/home/titilambert/gits/domo/homeassitant/config/deps/pyowm/webapi25/weather.py", line 462, in weather_from_dictionary
    wind = d['wind'].copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```

This patch fixes this error