### PR TITLE
Adding an OWMError class as base for all other errors.

### DIFF
--- a/pyowm/exceptions/__init__.py
+++ b/pyowm/exceptions/__init__.py
@@ -1,0 +1,7 @@
+"""
+Module containing the OWMError class as base for all other OWM errors
+"""
+
+
+class OWMError(Exception):
+    pass

--- a/pyowm/exceptions/api_call_error.py
+++ b/pyowm/exceptions/api_call_error.py
@@ -3,9 +3,10 @@ Module containing APICallError class
 """
 
 import os
+from pyowm.exceptions import OWMError
 
 
-class APICallError(Exception):
+class APICallError(OWMError):
     """
     Error class that represents failures when invoking OWM web API, in example
     due to network errors.

--- a/pyowm/exceptions/api_response_error.py
+++ b/pyowm/exceptions/api_response_error.py
@@ -3,9 +3,10 @@ Module containing APIResponseError class
 """
 
 import os
+from pyowm.exceptions import OWMError
 
 
-class APIResponseError(Exception):
+class APIResponseError(OWMError):
     """
     Error class that represents HTTP error status codes in OWM web API
     responses.

--- a/pyowm/exceptions/not_found_error.py
+++ b/pyowm/exceptions/not_found_error.py
@@ -3,9 +3,10 @@ Module containing NotFoundError class
 """
 
 import os
+from pyowm.exceptions import OWMError
 
 
-class NotFoundError(Exception):
+class NotFoundError(OWMError):
     """
     Error class that represents the situation when an entity is not found into
     a collection of entities.

--- a/pyowm/exceptions/parse_response_error.py
+++ b/pyowm/exceptions/parse_response_error.py
@@ -2,9 +2,10 @@
 Module containing ParseResponseError class
 """
 import os
+from pyowm.exceptions import OWMError
 
 
-class ParseResponseError(Exception):
+class ParseResponseError(OWMError):
     """
     Error class that represents failures when parsing payload data in HTTP
     responses sent by the OWM web API.


### PR DESCRIPTION
This makes it easier for users who just want to catch any OWM error as they can now catch the base class instead of each individual error class.