### PR TITLE
add title case to startswith to match cities

### DIFF
--- a/pyowm/webapi25/cityidregistry.py
+++ b/pyowm/webapi25/cityidregistry.py
@@ -77,7 +77,7 @@ class CityIDRegistry():
     
     def _match_line(self, city_name, lines):
         for line in lines:
-            if line.startswith(city_name.lower()):
+            if line.startswith(city_name.title()) or line.startswith(city_name.lower()):
                 return line.strip()
         return None
 


### PR DESCRIPTION
Now at least finds names, but only the FIRST one of what may be many places with the same name.
See https://github.com/csparpa/pyowm/issues/150 for more detail.