### PR TITLE
set use_ssl to True in the default configuration

### DIFF
--- a/pyowm/config.py
+++ b/pyowm/config.py
@@ -7,7 +7,7 @@ DEFAULT_CONFIG = {
     'subscription_type': SubscriptionTypeEnum.FREE,
     'language': 'en',
     'connection': {
-        'use_ssl': False,
+        'use_ssl': True,
         'verify_ssl_certs': True,
         'use_proxy': False,
         'timeout_secs': 5


### PR DESCRIPTION
Set use_ssl to True.

2 Unit tests are failing, but this tests are failing also, if we leave the option on False.

<details> 
<summary>Failed unit tests</summary>

```
======================================================================
FAIL: test_get_coi (tests.unit.airpollutionapi30.test_airpollution_client.TestAirPollutionHttpClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/robert/Documents/github/pyowm/tests/unit/airpollutionapi30/test_airpollution_client.py", line 42, in test_get_coi
    self.assertEqual(expected_url, result)
AssertionError: 'co/43.75,8.25/current.json' != {'time': '2016-10-01T13:07:01Z', 'locatio[342 chars]07}]}

======================================================================
FAIL: test_get_o3 (tests.unit.airpollutionapi30.test_airpollution_client.TestAirPollutionHttpClient)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/robert/Documents/github/pyowm/tests/unit/airpollutionapi30/test_airpollution_client.py", line 93, in test_get_o3
    self.assertEqual(expected_url, result)
AssertionError: 'o3/43.75,8.25/current.json' != {'time': '2016-10-06T13:32:53Z', 'locatio[68 chars]0781}

```

</details>

I only have the free subscription, so please can you run the integration tests again.