### PR TITLE
Fix timezone-aware datetimes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,6 +18,7 @@ Code
   * [txemi](https://github.com/txemi)
   * [camponez](https://github.com/camponez)
   * [dev-iks](https://github.com/dev-iks)
+  * [eumiro](https://github.com/eumiro)
 
 Docs
 ----

--- a/pyowm/utils/formatting.py
+++ b/pyowm/utils/formatting.py
@@ -1,23 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from calendar import timegm
-from datetime import datetime, timedelta, timezone, tzinfo
-
-ZERO = timedelta(0)
-
-
-class UTC(tzinfo):
-    """UTC"""
-
-    def utcoffset(self, dt):
-        return ZERO
-
-    def tzname(self, dt):
-        return "UTC"
-
-    def dst(self, dt):
-        return ZERO
+from datetime import datetime, timedelta, timezone
 
 
 def timeformat(timeobject, timeformat):
@@ -65,10 +49,9 @@ def to_date(timeobject):
             raise ValueError("The time value is a negative number")
         return datetime.fromtimestamp(timeobject, tz=timezone.utc)
     elif isinstance(timeobject, datetime):
-        return timeobject.replace(tzinfo=UTC())
+        return timeobject.replace(microsecond=0)
     elif isinstance(timeobject, str):
-        return datetime.strptime(timeobject,
-                                 '%Y-%m-%d %H:%M:%S+00').replace(tzinfo=UTC())
+        return datetime.fromisoformat(timeobject, "seconds")
     else:
         raise TypeError('The time value must be expressed either by an int ' \
                          'UNIX time, a datetime.datetime object or an ' \
@@ -93,9 +76,9 @@ def to_ISO8601(timeobject):
     if isinstance(timeobject, int):
         if timeobject < 0:
             raise ValueError("The time value is a negative number")
-        return datetime.fromtimestamp(timeobject, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S+00')
+        return datetime.fromtimestamp(timeobject, tz=timezone.utc).isoformat(' ', 'seconds')
     elif isinstance(timeobject, datetime):
-        return timeobject.strftime('%Y-%m-%d %H:%M:%S+00')
+        return timeobject.isoformat(' ', 'seconds')
     elif isinstance(timeobject, str):
         return timeobject
     else:
@@ -145,7 +128,7 @@ def ISO8601_to_UNIXtime(iso):
 
     """
     try:
-        d = datetime.strptime(iso, '%Y-%m-%d %H:%M:%S+00')
+        d = datetime.fromisoformat(iso)
     except ValueError:
         raise ValueError(__name__ + ": bad format for input ISO8601 string, ' \
             'should have been: YYYY-MM-DD HH:MM:SS+00")
@@ -161,4 +144,4 @@ def datetime_to_UNIXtime(date):
     :returns: an int UNIXtime
     :raises: *TypeError* when bad argument types are provided
     """
-    return timegm(date.timetuple())
+    return int(date.timestamp())

--- a/pyowm/utils/timestamps.py
+++ b/pyowm/utils/timestamps.py
@@ -92,11 +92,12 @@ def tomorrow(hour=None, minute=None):
     :raises: *ValueError* when hour or minute have bad values
 
     """
+    now = datetime.now(timezone.utc)
     if hour is None:
-        hour = datetime.now(timezone.utc).hour
+        hour = now.hour
     if minute is None:
-        minute = datetime.now(timezone.utc).minute
-    tomorrow_date = date.today() + timedelta(days=1)
+        minute = now.minute
+    tomorrow_date = now.date() + timedelta(days=1)
     return datetime(tomorrow_date.year, tomorrow_date.month, tomorrow_date.day,
                     hour, minute, 0)
 
@@ -119,11 +120,12 @@ def yesterday(hour=None, minute=None):
     :returns: a ``datetime.datetime`` object
     :raises: *ValueError* when hour or minute have bad values
     """
+    now = datetime.now(timezone.utc)
     if hour is None:
-        hour = datetime.now(timezone.utc).hour
+        hour = now.hour
     if minute is None:
-        minute = datetime.now(timezone.utc).minute
-    yesterday_date = date.today() + timedelta(days=-1)
+        minute = now.minute
+    yesterday_date = now.date() + timedelta(days=-1)
     return datetime(yesterday_date.year, yesterday_date.month,
                     yesterday_date.day, hour, minute, 0)
 

--- a/pyowm/utils/timestamps.py
+++ b/pyowm/utils/timestamps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from pyowm.utils import formatting
 
 
@@ -18,7 +18,7 @@ def now(timeformat='date'):
     :raises: ValueError when unknown timeformat switches are provided or
         when negative time values are provided
     """
-    return formatting.timeformat(datetime.now(), timeformat)
+    return formatting.timeformat(datetime.now(timezone.utc), timeformat)
 
 
 def next_hour(date=None):
@@ -93,9 +93,9 @@ def tomorrow(hour=None, minute=None):
 
     """
     if hour is None:
-        hour = datetime.now().hour
+        hour = datetime.now(timezone.utc).hour
     if minute is None:
-        minute = datetime.now().minute
+        minute = datetime.now(timezone.utc).minute
     tomorrow_date = date.today() + timedelta(days=1)
     return datetime(tomorrow_date.year, tomorrow_date.month, tomorrow_date.day,
                     hour, minute, 0)
@@ -120,9 +120,9 @@ def yesterday(hour=None, minute=None):
     :raises: *ValueError* when hour or minute have bad values
     """
     if hour is None:
-        hour = datetime.now().hour
+        hour = datetime.now(timezone.utc).hour
     if minute is None:
-        minute = datetime.now().minute
+        minute = datetime.now(timezone.utc).minute
     yesterday_date = date.today() + timedelta(days=-1)
     return datetime(yesterday_date.year, yesterday_date.month,
                     yesterday_date.day, hour, minute, 0)
@@ -214,7 +214,7 @@ def next_year(date=None):
 
 def _timedelta_hours(offset, date=None):
     if date is None:
-        return datetime.now() + timedelta(hours=offset)
+        return datetime.now(timezone.utc) + timedelta(hours=offset)
     else:
         assert isinstance(date, datetime), __name__ + \
             ": 'date' must be a datetime.datetime object"
@@ -223,7 +223,7 @@ def _timedelta_hours(offset, date=None):
 
 def _timedelta_days(offset, date=None):
     if date is None:
-        return datetime.now() + timedelta(days=offset)
+        return datetime.now(timezone.utc) + timedelta(days=offset)
     else:
         assert isinstance(date, datetime), __name__ + \
             ": 'date' must be a datetime.datetime object"
@@ -232,7 +232,7 @@ def _timedelta_days(offset, date=None):
 
 def _timedelta_months(offset, date=None):
     if date is None:
-        return datetime.now() + timedelta(days=offset * 30)
+        return datetime.now(timezone.utc) + timedelta(days=offset * 30)
     else:
         assert isinstance(date, datetime), __name__ + \
             ": 'date' must be a datetime.datetime object"
@@ -241,7 +241,7 @@ def _timedelta_months(offset, date=None):
 
 def _timedelta_years(offset, date=None):
     if date is None:
-        return datetime.now() + timedelta(days=offset * 365)
+        return datetime.now(timezone.utc) + timedelta(days=offset * 365)
     else:
         assert isinstance(date, datetime), __name__ + \
             ": 'date' must be a datetime.datetime object"

--- a/pyowm/weatherapi25/weather_manager.py
+++ b/pyowm/weatherapi25/weather_manager.py
@@ -550,7 +550,7 @@ class WeatherManager:
         geo.assert_is_lon(lon)
         geo.assert_is_lat(lat)
         if dt is None:
-            dt = int((datetime.now() - timedelta(days=5)).replace(tzinfo=timezone.utc).timestamp())
+            dt = int((datetime.now(timezone.utc) - timedelta(days=5)).timestamp())
         else:
             if not isinstance(dt, int):
                 raise ValueError("dt must be of type int")

--- a/tests/unit/utils/test_timestamps.py
+++ b/tests/unit/utils/test_timestamps.py
@@ -135,12 +135,12 @@ class TestTimeUtils(unittest.TestCase):
     def test_now(self):
         expected = datetime.now(timezone.utc)
         result = timestamps.now()
-        self.assertEquals(result.year, expected.year)
-        self.assertEquals(result.month, expected.month)
-        self.assertEquals(result.day, expected.day)
-        self.assertEquals(result.hour, expected.hour)
-        self.assertEquals(result.minute, expected.minute)
-        self.assertEquals(result.second, expected.second)
+        self.assertEqual(result.year, expected.year)
+        self.assertEqual(result.month, expected.month)
+        self.assertEqual(result.day, expected.day)
+        self.assertEqual(result.hour, expected.hour)
+        self.assertEqual(result.minute, expected.minute)
+        self.assertEqual(result.second, expected.second)
 
     def test_last_month(self):
         result = timestamps.last_month()

--- a/tests/unit/utils/test_timestamps.py
+++ b/tests/unit/utils/test_timestamps.py
@@ -2,14 +2,14 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from datetime import datetime, date, timedelta
+from datetime import datetime, date, timedelta, timezone
 from pyowm.utils import timestamps, formatting
 
 
 class TestTimeUtils(unittest.TestCase):
 
     def test_tomorrow(self):
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         tomorrow = date.today() + timedelta(days=1)
         result = timestamps.tomorrow()
         expected = datetime(tomorrow.year, tomorrow.month, tomorrow.day,
@@ -24,7 +24,7 @@ class TestTimeUtils(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_tomorrow_with_hour_only(self):
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         tomorrow = date.today() + timedelta(days=1)
         result = timestamps.tomorrow(6)
         expected = datetime(tomorrow.year, tomorrow.month, tomorrow.day, 6,
@@ -32,7 +32,7 @@ class TestTimeUtils(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_yesterday(self):
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         yesterday = date.today() + timedelta(days=-1)
         result = timestamps.yesterday()
         expected = datetime(yesterday.year, yesterday.month, yesterday.day,
@@ -47,7 +47,7 @@ class TestTimeUtils(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_yesterday_with_hour_only(self):
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         yesterday = date.today() + timedelta(days=-1)
         result = timestamps.yesterday(6)
         expected = datetime(yesterday.year, yesterday.month, yesterday.day, 6,
@@ -56,84 +56,84 @@ class TestTimeUtils(unittest.TestCase):
 
     def test_next_three_hours(self):
         result = timestamps.next_three_hours()
-        expected = datetime.now() + timedelta(hours=3)
+        expected = datetime.now(timezone.utc) + timedelta(hours=3)
         self.assertAlmostEqual(
            float(formatting.to_UNIXtime(expected)),
            float(formatting.to_UNIXtime(result)))
 
     def test_next_three_hours_after_specified_time(self):
-        d = datetime(2013, 12, 7, 15, 46, 12)
+        d = datetime(2013, 12, 7, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(hours=3)
         result = timestamps.next_three_hours(d)
         self.assertAlmostEqual(expected, result)
 
     def test_last_three_hours(self):
         result = timestamps.last_three_hours()
-        expected = datetime.now() + timedelta(hours=-3)
+        expected = datetime.now(timezone.utc) + timedelta(hours=-3)
         self.assertAlmostEqual(
            float(formatting.to_UNIXtime(expected)),
            float(formatting.to_UNIXtime(result)))
 
     def test_last_three_hours_before_specified_time(self):
-        d = datetime(2013, 12, 7, 15, 46, 12)
+        d = datetime(2013, 12, 7, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(hours=-3)
         result = timestamps.last_three_hours(d)
         self.assertAlmostEqual(expected, result)
 
     def test_next_hour(self):
         result = timestamps.next_hour()
-        expected = datetime.now() + timedelta(hours=1)
+        expected = datetime.now(timezone.utc) + timedelta(hours=1)
         self.assertAlmostEqual(
            float(formatting.to_UNIXtime(expected)),
            float(formatting.to_UNIXtime(result)))
 
     def test_next_hour_after_specified_time(self):
-        d = datetime(2013, 12, 7, 15, 46, 12)
+        d = datetime(2013, 12, 7, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(hours=1)
         result = timestamps.next_hour(d)
         self.assertAlmostEqual(expected, result)
 
     def test_next_week(self):
         result = timestamps.next_week()
-        expected = datetime.now() + timedelta(days=7)
+        expected = datetime.now(timezone.utc) + timedelta(days=7)
         self.assertAlmostEqual(
            float(formatting.to_UNIXtime(expected)),
            float(formatting.to_UNIXtime(result)))
 
     def test_next_week_after_specified_time(self):
-        d = datetime(2013, 12, 7, 15, 46, 12)
+        d = datetime(2013, 12, 7, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(days=7)
         result = timestamps.next_week(d)
         self.assertAlmostEqual(expected, result)
 
     def test_last_week(self):
         result = timestamps.last_week()
-        expected = datetime.now() + timedelta(days=-7)
+        expected = datetime.now(timezone.utc) + timedelta(days=-7)
         self.assertAlmostEqual(
            float(formatting.to_UNIXtime(expected)),
            float(formatting.to_UNIXtime(result)))
 
     def test_last_week_after_specified_time(self):
-        d = datetime(2013, 12, 7, 15, 46, 12)
+        d = datetime(2013, 12, 7, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(days=-7)
         result = timestamps.last_week(d)
         self.assertAlmostEqual(expected, result)
 
     def test_last_hour(self):
         result = timestamps.last_hour()
-        expected = datetime.now() + timedelta(hours=-1)
+        expected = datetime.now(timezone.utc) + timedelta(hours=-1)
         self.assertAlmostEqual(
            float(formatting.to_UNIXtime(expected)),
            float(formatting.to_UNIXtime(result)))
 
     def test_last_hour_after_specified_time(self):
-        d = datetime(2013, 12, 7, 15, 46, 12)
+        d = datetime(2013, 12, 7, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(hours=-1)
         result = timestamps.last_hour(d)
         self.assertAlmostEqual(expected, result)
         
     def test_now(self):
-        expected = datetime.now()
+        expected = datetime.now(timezone.utc)
         result = timestamps.now()
         self.assertEquals(result.year, expected.year)
         self.assertEquals(result.month, expected.month)
@@ -144,52 +144,52 @@ class TestTimeUtils(unittest.TestCase):
 
     def test_last_month(self):
         result = timestamps.last_month()
-        expected = datetime.now() + timedelta(days=-30)
+        expected = datetime.now(timezone.utc) + timedelta(days=-30)
         self.assertAlmostEqual(
             float(formatting.to_UNIXtime(expected)),
             float(formatting.to_UNIXtime(result)))
 
     def test_last_month_after_specified_time(self):
-        d = datetime(2015, 10, 1, 15, 46, 12)
+        d = datetime(2015, 10, 1, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(days=-30)
         result = timestamps.last_month(d)
         self.assertAlmostEqual(expected, result)
 
     def test_next_month(self):
         result = timestamps.next_month()
-        expected = datetime.now() + timedelta(days=30)
+        expected = datetime.now(timezone.utc) + timedelta(days=30)
         self.assertAlmostEqual(
             float(formatting.to_UNIXtime(expected)),
             float(formatting.to_UNIXtime(result)))
 
     def test_next_month_after_specified_time(self):
-        d = datetime(2015, 10, 1, 15, 46, 12)
+        d = datetime(2015, 10, 1, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(days=30)
         result = timestamps.next_month(d)
         self.assertAlmostEqual(expected, result)
 
     def test_last_year(self):
         result = timestamps.last_year()
-        expected = datetime.now() + timedelta(days=-365)
+        expected = datetime.now(timezone.utc) + timedelta(days=-365)
         self.assertAlmostEqual(
             float(formatting.to_UNIXtime(expected)),
             float(formatting.to_UNIXtime(result)))
 
     def test_last_year_after_specified_time(self):
-        d = datetime(2015, 10, 1, 15, 46, 12)
+        d = datetime(2015, 10, 1, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(days=-365)
         result = timestamps.last_year(d)
         self.assertAlmostEqual(expected, result)
 
     def test_next_year(self):
         result = timestamps.next_year()
-        expected = datetime.now() + timedelta(days=365)
+        expected = datetime.now(timezone.utc) + timedelta(days=365)
         self.assertAlmostEqual(
             float(formatting.to_UNIXtime(expected)),
             float(formatting.to_UNIXtime(result)))
 
     def test_next_year_after_specified_time(self):
-        d = datetime(2015, 10, 1, 15, 46, 12)
+        d = datetime(2015, 10, 1, 15, 46, 12, 0, timezone.utc)
         expected = d + timedelta(days=365)
         result = timestamps.next_year(d)
         self.assertAlmostEqual(expected, result)


### PR DESCRIPTION
This adds a `tzinfo` to all datetime objects (default UTC) and consolidates the conversions between the formats (works in Python 3.7+ just like the whole pyowm).

-Fixes #319 