### PR TITLE
Add One Call functionality: (1) exclude parts and (2) set desired units

### DIFF
--- a/pyowm/weatherapi25/one_call.py
+++ b/pyowm/weatherapi25/one_call.py
@@ -12,7 +12,8 @@ class OneCall:
                  lon: Union[int, float],
                  timezone: str,
                  current: Weather,
-                 forecast_hourly: [Weather],
+                 forecast_minutely:Optional[Weather] = None,
+                 forecast_hourly:Optional[Weather] = None,
                  forecast_daily: Optional[Weather] = None
                  ) -> None:
         geo.assert_is_lat(lat)
@@ -26,7 +27,7 @@ class OneCall:
         if current is None:
             raise ValueError("'current' must be set")
         self.current = current
-
+        self.forecast_minutely = forecast_minutely
         self.forecast_hourly = forecast_hourly
         self.forecast_daily = forecast_daily
 
@@ -78,7 +79,12 @@ class OneCall:
 
         try:
             current = Weather.from_dict(the_dict["current"])
-            hourly = [Weather.from_dict(item) for item in the_dict["hourly"]]
+            minutely = None
+            if "minutely" in the_dict:
+                minutely = [Weather.from_dict(item) for item in the_dict["minutely"]]
+            hourly = None
+            if "hourly" in the_dict:
+                hourly = [Weather.from_dict(item) for item in the_dict["hourly"]]
             daily = None
             if "daily" in the_dict:
                 daily = [Weather.from_dict(item) for item in the_dict["daily"]]
@@ -91,6 +97,7 @@ class OneCall:
             lon=the_dict.get("lon", None),
             timezone=the_dict.get("timezone", None),
             current=current,
+            forecast_minutely=minutely,
             forecast_hourly=hourly,
             forecast_daily=daily
         )

--- a/pyowm/weatherapi25/weather_manager.py
+++ b/pyowm/weatherapi25/weather_manager.py
@@ -499,7 +499,7 @@ class WeatherManager:
             sh.interval = interval
         return sh
 
-    def one_call(self, lat: Union[int, float], lon: Union[int, float]) -> one_call.OneCall:
+    def one_call(self, lat: Union[int, float], lon: Union[int, float], **kwargs) -> one_call.OneCall:
         """
         Queries the OWM Weather API with one call for current weather information and forecast for the
         specified geographic coordinates.
@@ -523,6 +523,9 @@ class WeatherManager:
         geo.assert_is_lon(lon)
         geo.assert_is_lat(lat)
         params = {'lon': lon, 'lat': lat}
+        for key , value in kwargs.items():
+            if key == 'exclude': params['exclude'] = value
+            if key == 'units': params['units'] = value
 
         _, json_data = self.http_client.get_json(ONE_CALL_URI, params=params)
         return one_call.OneCall.from_dict(json_data)


### PR DESCRIPTION
I added the ability for one call requests to use both an "exclude" parameter and "units" parameter. As part of that, in the OneCall object, I made the hourly weather data optional, and added the ability to handle minutely weather data. I left the current weather as required.

As per the [OWM specs](https://openweathermap.org/api/one-call-api), exclude may be set to any subset of: current,minutely,hourly,daily; and units may be set to: metric or imperial. 