### PR TITLE
Add a workaround for minutely precipitation

### DIFF
--- a/pyowm/weatherapi25/weather.py
+++ b/pyowm/weatherapi25/weather.py
@@ -319,6 +319,10 @@ class Weather:
             elif 'all' in the_dict['clouds']:
                 clouds = the_dict['clouds']['all']
 
+        # -- precipitation workaround
+        if 'precipitation' in the_dict and 'rain' not in the_dict:
+            the_dict['rain'] = the_dict['precipitation']
+
         # -- rain
         rain = dict()
         if 'rain' in the_dict:


### PR DESCRIPTION
This PR adds a workaround that stores precipitation data from minutely forecast. A onecall JSON response that contains a `minutely` array uses the precipitation key instead of rain (to save on data) looks like this:

```
{
  "minutely": [{ "precipitation": 0.443, "dt": 1601552873 }, ...],
  ...
}
```

This solution takes the precipitation field and copies it to the `rain` field if `rain` wasn't already set. The result is that the precipitation data ends up in the rain field encapsulated in a dict like: `{ 'all': <precipitation_value> }`.

Fixes #343 