### PR TITLE
Bug Fixed.Parsing city names with 1 or more commas

### DIFF
--- a/pyowm/commons/cityidregistry.py
+++ b/pyowm/commons/cityidregistry.py
@@ -145,10 +145,9 @@ class CityIDRegistry:
         # the specified matching style
         for line in lines:
             tokens = line.split(",")
-            # sometimes city names have an inner comma...
-            if len(tokens) == 6:
-                tokens = [tokens[0]+','+tokens[1], tokens[2], tokens[3],
-                          tokens[4], tokens[5]]
+            # sometimes city names have one or more inner commas
+            if len(tokens) > 5:
+                tokens = [','.join(tokens[:-4]), *tokens[-4:]]
             # check country
             if country is not None:
                 if tokens[4] != country:

--- a/tests/unit/commons/test_cityidregistry.py
+++ b/tests/unit/commons/test_cityidregistry.py
@@ -30,7 +30,9 @@ Abbeville,4568985,34.178169,-82.379013,US
 Abbeville,4829449,31.57184,-85.250488,US
 Bologna,2829449,30.57184,-83.250488,IT"""
     _test_file_contents_with_commas_in_names = """Thalassery,1254780,11.75,75.533333,IN
-Thale, Stadt,6550950,51.7528,11.058,DE"""
+Thale, Stadt,6550950,51.7528,11.058,DE
+Pitcairn,5206361,40.403118,-79.778099,PA
+Pitcairn, Henderson, Ducie and Oeno Islands,4030699,-25.066669,-130.100006,PN"""
 
     test_filelines = [
         'Londinieres,2997784,49.831871,1.40232,FR\n',
@@ -251,6 +253,32 @@ Thale, Stadt,6550950,51.7528,11.058,DE"""
         self.assertEqual(1, len(result))
         self.assertTrue((6550950, 'Thale, Stadt', 'DE') in result)
 
+        result = self._instance.ids_for("Pitcairn, Henderson, Ducie and Oeno Islands")
+        self.assertEqual(1, len(result))
+        self.assertTrue((4030699, 'Pitcairn, Henderson, Ducie and Oeno Islands', 'PN') in result)
+
+        CityIDRegistry._get_lines = ref_to_original
+
+    def test_ids_for_with_commas_in_city_names_like(self):
+        ref_to_original = CityIDRegistry._get_lines
+        CityIDRegistry._get_lines = self._mock_test_file_contents_with_commas_in_names
+
+        result = self._instance.ids_for("Pitca", matching='like')
+        self.assertTrue((5206361, 'Pitcairn', 'PA') in result)
+        self.assertTrue((4030699, 'Pitcairn, Henderson, Ducie and Oeno Islands', 'PN') in result)
+
+        CityIDRegistry._get_lines = ref_to_original
+
+    def test_ids_for_with_commas_in_city_names_like_country(self):
+        ref_to_original = CityIDRegistry._get_lines
+        CityIDRegistry._get_lines = self._mock_test_file_contents_with_commas_in_names
+
+        result = self._instance.ids_for("Pitc", country='PA',matching='like')
+        self.assertTrue((5206361, 'Pitcairn', 'PA') in result)
+
+        result = self._instance.ids_for("Ducie and Oeno", country='PN',matching='like')
+        self.assertTrue((4030699, 'Pitcairn, Henderson, Ducie and Oeno Islands', 'PN') in result)
+
         CityIDRegistry._get_lines = ref_to_original
 
     # tests for locations retrieval
@@ -372,6 +400,34 @@ Thale, Stadt,6550950,51.7528,11.058,DE"""
         self._assertLocationsEqual(
             Location('Thale, Stadt', 11.058, 51.7528, 6550950, 'DE'),
             result[0])
+
+        result = self._instance.locations_for("Pitcairn, Henderson, Ducie and Oeno Islands")
+        self.assertEqual(1, len(result))
+        self._assertLocationsEqual(
+            Location('Pitcairn, Henderson, Ducie and Oeno Islands', -130.100006, -25.066669, 4030699, 'PN'),
+            result[0])
+
+        CityIDRegistry._get_lines = ref_to_original
+
+    def test_locations_for_with_commas_in_city_names_like(self):
+        ref_to_original = CityIDRegistry._get_lines
+        CityIDRegistry._get_lines = self._mock_test_file_contents_with_commas_in_names
+
+        result = self._instance.locations_for("Pitcai", matching="like")
+        self._assertLocationsEqual(result[0], Location('Pitcairn', -79.778099, 40.403118, 5206361, 'PA'))
+        self._assertLocationsEqual(result[1], Location('Pitcairn, Henderson, Ducie and Oeno Islands', -130.100006, -25.066669, 4030699, 'PN'))
+
+        CityIDRegistry._get_lines = ref_to_original
+
+    def test_locations_for_with_commas_in_city_names_like_country(self):
+        ref_to_original = CityIDRegistry._get_lines
+        CityIDRegistry._get_lines = self._mock_test_file_contents_with_commas_in_names
+
+        result = self._instance.locations_for("Pitca", country='PA', matching="like")
+        self._assertLocationsEqual(result[0], Location('Pitcairn', -79.778099, 40.403118, 5206361, 'PA'))
+
+        result = self._instance.locations_for("Ducie", country='PN', matching="like")
+        self._assertLocationsEqual(result[1], Location('Pitcairn, Henderson, Ducie and Oeno Islands', -130.100006, -25.066669, 4030699, 'PN'))
 
         CityIDRegistry._get_lines = ref_to_original
 


### PR DESCRIPTION
The length of the 'tokens' variable should be 5. City names like "Southern Nations, Nationalities, and People's Region," "Saint Helena, Ascension, and Tristan da Cunha" and a few others were split by a comma into more than 2 parts, causing the 'tokens' length to be more than expected. The longest name is "Villa Presidente Frei, Ñuñoa, Santiago, Chile" (id 7874740). It has three commas, hence split into 4 parts.