### PR TITLE
Add support for precipitation probability from onecall API

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@ Contributors will be shown in alphabetical order
 
 Code
 ----
+  * [ahertz](https://github.com/ahertz)
   * [alechewitt](https://github.com/alechewitt)
   * [camponez](https://github.com/camponez)
   * [dev-iks](https://github.com/dev-iks)

--- a/pyowm/constants.py
+++ b/pyowm/constants.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-PYOWM_VERSION = (3, 1, 0)
+PYOWM_VERSION = (3, 1, 1)
 AGRO_API_VERSION = (1, 0, 0)
 AIRPOLLUTION_API_VERSION = (3, 0, 0)
 ALERT_API_VERSION = (3, 0, 0)

--- a/pyowm/weatherapi25/weather.py
+++ b/pyowm/weatherapi25/weather.py
@@ -54,6 +54,8 @@ class Weather:
     :type utc_offset: int or None
     :param uvi: UV index
     :type uvi: int, float or None
+    :param precipitation_probability: Probability of precipitation (forecast only)
+    :type precipitation_probability: float or None
     :returns:  a *Weather* instance
     :raises: *ValueError* when negative values are provided for non-negative quantities
 
@@ -63,7 +65,7 @@ class Weather:
                  snow, wind, humidity, pressure, temperature, status,
                  detailed_status, weather_code, weather_icon_name,
                  visibility_distance, dewpoint, humidex, heat_index,
-                 utc_offset=None, uvi=None):
+                 utc_offset=None, uvi=None, precipitation_probability=None):
         if reference_time < 0:
             raise ValueError("'reference_time' must be greater than 0")
         self.ref_time = reference_time
@@ -117,6 +119,12 @@ class Weather:
             raise ValueError("'uvi' must be grater than or equal to 0")
         self.uvi = uvi
 
+        if precipitation_probability is not None and \
+           (precipitation_probability < 0.0 or precipitation_probability > 1.0):
+            raise ValueError("'precipitation_probability' must be between " \
+                             "0.0 and 1.0")
+        self.precipitation_probability = precipitation_probability
+        
     def reference_time(self, timeformat='unix'):
         """Returns the GMT time telling when the weather was measured
 
@@ -440,11 +448,15 @@ class Weather:
         # -- UV index
         uvi = the_dict.get('uvi', None)
 
+        # -- Precipitation probability
+        precipitation_probability = the_dict.get('pop', None)
+
         return Weather(reference_time, sunset_time, sunrise_time, clouds,
                        rain, snow, wind, humidity, pressure, temperature,
                        status, detailed_status, weather_code, weather_icon_name,
                        visibility_distance, dewpoint, humidex, heat_index,
-                       utc_offset=utc_offset, uvi=uvi)
+                       utc_offset=utc_offset, uvi=uvi,
+                       precipitation_probability=precipitation_probability)
 
     @classmethod
     def from_dict_of_lists(cls, the_dict):
@@ -513,4 +525,5 @@ class Weather:
                 'humidex': self.humidex,
                 'heat_index': self.heat_index,
                 'utc_offset': self.utc_offset,
-                'uvi': self.uvi}
+                'uvi': self.uvi,
+                'precipitation_probability': self.precipitation_probability}

--- a/tests/unit/weatherapi25/test_forecast.py
+++ b/tests/unit/weatherapi25/test_forecast.py
@@ -21,14 +21,16 @@ class TestForecast(unittest.TestCase):
                                {"temp": 294.199, "temp_kf": -1.899, "temp_max": 296.098,
                                 "temp_min": 294.199
                                 },
-                               "Clouds", "Overcast clouds", 804, "04d", 1000, 300.0, 298.0, 296.0),
+                               "Clouds", "Overcast clouds", 804, "04d", 1000, 300.0, 298.0, 296.0,
+                               precipitation_probability=0.25),
                        Weather(1378459690, 1378496480, 1378449510, 23, {"all": 10},
                                {"all": 0}, {"deg": 103.4, "speed": 4.2}, 12,
                                {"press": 1070.119, "sea_level": 1078.589},
                                {"temp": 297.199, "temp_kf": -1.899, "temp_max": 299.0,
                                 "temp_min": 295.6
                                 },
-                               "Clear", "Sky is clear", 804, "02d", 1000, 300.0, 298.0, 296.0)
+                               "Clear", "Sky is clear", 804, "02d", 1000, 300.0, 298.0, 296.0,
+                               precipitation_probability=0.0)
                        ]
     __test_n_weathers = len(__test_weathers)
     __test_instance = Forecast("daily", __test_reception_time, __test_location,
@@ -54,7 +56,8 @@ class TestForecast(unittest.TestCase):
                          '"sunset_time": 1378496400, "pressure": {"press": 1030.119,' \
                          ' "sea_level": 1038.589}, "sunrise_time": 1378449600, ' \
                          '"heat_index": 296.0, "weather_icon_name": "04d", "wind": ' \
-                         '{"speed": 1.1, "deg": 252.002}, "utc_offset": null, "uvi": null}, {"status": "Clear", ' \
+                         '{"speed": 1.1, "deg": 252.002}, "utc_offset": null, "uvi": null, ' \
+                         '"precipitation_probability": 0.25}, {"status": "Clear", ' \
                          '"visibility_distance": 1000, "humidity": 12, ' \
                          '"clouds": 23, "temperature": {"temp_kf": -1.899, ' \
                          '"temp_max": 299.0, "temp": 297.199, "temp_min": 295.6}, ' \
@@ -65,7 +68,7 @@ class TestForecast(unittest.TestCase):
                          '{"press": 1070.119, "sea_level": 1078.589}, ' \
                          '"sunrise_time": 1378449510, "heat_index": 296.0, ' \
                          '"weather_icon_name": "02d", "wind": {"speed": 4.2, ' \
-                         '"deg": 103.4}, "utc_offset": null, "uvi": null}]}'
+                         '"deg": 103.4}, "utc_offset": null, "uvi": null, "precipitation_probability": 0.0}]}'
 
     def test_actualize(self):
         weathers = [Weather(1378459200, 1378496400, 1378449600, 67,

--- a/tests/unit/weatherapi25/test_observation.py
+++ b/tests/unit/weatherapi25/test_observation.py
@@ -52,7 +52,7 @@ class TestObservation(unittest.TestCase):
                             '"sunrise_time": 1378449600, "heat_index": 296.0, ' \
                             '"weather_icon_name": "04d", "wind": ' \
                             '{"speed": 1.1, "deg": 252.002}, "utc_offset": null, ' \
-                            '"uvi": null}}'
+                            '"uvi": null, "precipitation_probability": null}}'
 
     def test_init_fails_when_reception_time_is_negative(self):
         self.assertRaises(ValueError, Observation, -1234567, \

--- a/tests/unit/weatherapi25/test_weather.py
+++ b/tests/unit/weatherapi25/test_weather.py
@@ -51,6 +51,7 @@ class TestWeather(unittest.TestCase):
     __test_dewpoint = 300.0
     __test_humidex = 298.0
     __test_heat_index = 40.0
+    __test_precipitation_probability = 0.5
 
     __test_instance = Weather(__test_reference_time, __test_sunset_time,
                               __test_sunrise_time, __test_clouds, __test_rain,
@@ -59,7 +60,8 @@ class TestWeather(unittest.TestCase):
                               __test_status, __test_detailed_status,
                               __test_weather_code, __test_weather_icon_name,
                               __test_visibility_distance, __test_dewpoint,
-                              __test_humidex, __test_heat_index)
+                              __test_humidex, __test_heat_index,
+                              precipitation_probability=__test_precipitation_probability)
 
     __bad_json = '{"a": "test", "b": 1.234, "c": [ "hello", "world"] }'
     __bad_json_2 = '{"list": [{"test":"fake"}] }'
@@ -75,7 +77,8 @@ class TestWeather(unittest.TestCase):
                         '{"press": 1030.119, "sea_level": 1038.589, "grnd_level": 1038.773}, ' \
                         '"sunrise_time": 1378449600, "heat_index": 40.0, ' \
                         '"weather_icon_name": "04d", "humidity": 57, "wind": ' \
-                        '{"speed": 1.1, "deg": 252.002, "gust": 2.09}, "utc_offset": null, "uvi": null}'
+                        '{"speed": 1.1, "deg": 252.002, "gust": 2.09}, "utc_offset": null, "uvi": null, ' \
+                        '"precipitation_probability": 0.5}'
 
     def test_init_fails_when_wrong_data_provided(self):
         self.assertRaises(ValueError, Weather, -9876543210,
@@ -138,6 +141,26 @@ class TestWeather(unittest.TestCase):
                           self.__test_weather_code, self.__test_weather_icon_name,
                           self.__test_visibility_distance, self.__test_dewpoint,
                           self.__test_humidex, self.__test_heat_index, uvi=-1)
+        self.assertRaises(ValueError, Weather, self.__test_reference_time,
+                          self.__test_sunset_time, self.__test_sunrise_time,
+                          self.__test_clouds, self.__test_rain, self.__test_snow,
+                          self.__test_wind, self.__test_humidity,
+                          self.__test_pressure, self.__test_temperature,
+                          self.__test_status, self.__test_detailed_status,
+                          self.__test_weather_code, self.__test_weather_icon_name,
+                          self.__test_visibility_distance, self.__test_dewpoint,
+                          self.__test_humidex, self.__test_heat_index,
+                          precipitation_probability=-1.0)
+        self.assertRaises(ValueError, Weather, self.__test_reference_time,
+                          self.__test_sunset_time, self.__test_sunrise_time,
+                          self.__test_clouds, self.__test_rain, self.__test_snow,
+                          self.__test_wind, self.__test_humidity,
+                          self.__test_pressure, self.__test_temperature,
+                          self.__test_status, self.__test_detailed_status,
+                          self.__test_weather_code, self.__test_weather_icon_name,
+                          self.__test_visibility_distance, self.__test_dewpoint,
+                          self.__test_humidex, self.__test_heat_index,
+                          precipitation_probability=2.0)
 
     def test_init_when_wind_is_none(self):
         instance = Weather(self.__test_reference_time,


### PR DESCRIPTION
The onecall API returns a probability of precipitation for hourly and daily forecasts, which are not currently captured by pyowm.  This patch adds support for them, when they are available.

The OWM api uses the name "pop" for this data point, but in the spirit of being explicit and obvious I'm using "precipitation_probability".  I'm happy to change that to "precip_prob" or even "pop" if you feel that it's too long.