### PR TITLE
read long_description from README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,10 @@ from setuptools import setup, find_packages
 from pyowm.__version__ import __author__, __author_email__, __description__, __license__, __title__,\
     __url__, __version__
 
+
+with open('README.md', 'r') as readme:
+    long_description = readme.read()
+
 setup(
     name=__title__,
     version=__version__,
@@ -12,8 +16,8 @@ setup(
     author_email=__author_email__,
     url=__url__,
     packages=find_packages(),
-    long_description="""PyOWM is a client Python wrapper library for OpenWeatherMap web APIs. It allows quick and easy 
-    consumption of OWM data from Python applications via a simple object model and in a human-friendly fashion.""",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
         'requests>=2.20.0,<3',


### PR DESCRIPTION
Currently, the project description on the PyPI page (https://pypi.org/project/pyowm/) is quite poor. A simple trick, used by many projects, is to use the README.md as PyPI project description. This pull requests reads and uses the contents for the `README.md` file as `long_description` and therefore info on the PyPI page.