### PR TITLE
update setup.py, add pkg excludes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author=__author__,
     author_email=__author_email__,
     url=__url__,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests','tests.*']),
     long_description="""PyOWM is a client Python wrapper library for OpenWeatherMap web APIs. It allows quick and easy 
     consumption of OWM data from Python applications via a simple object model and in a human-friendly fashion.""",
     include_package_data=True,


### PR DESCRIPTION
otherwise it tries to install a package 'tests' at top level, which is forbidden.

```
>>> Jobs: 13 of 14 complete, 1 failed               Load avg: 1.70, 1.13, 0.85
 * Package:    dev-python/pyowm-3.1.1
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   csparpa@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking pyowm-3.1.1.tar.gz to /var/tmp/portage/dev-python/pyowm-3.1.1/work
>>> Source unpacked in /var/tmp/portage/dev-python/pyowm-3.1.1/work
>>> Preparing source in /var/tmp/portage/dev-python/pyowm-3.1.1/work/pyowm-3.1.1 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/pyowm-3.1.1/work/pyowm-3.1.1 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/pyowm-3.1.1/work/pyowm-3.1.1 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
running build
running build_py
running install_egg_info
running egg_info
writing pyowm.egg-info/PKG-INFO
writing dependency_links to pyowm.egg-info/dependency_links.txt
writing requirements to pyowm.egg-info/requires.txt
writing top-level names to pyowm.egg-info/top_level.txt
reading manifest file 'pyowm.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'pyowm/requirements.txt'
writing manifest file 'pyowm.egg-info/SOURCES.txt'
Copying pyowm.egg-info to /var/tmp/portage/dev-python/pyowm-3.1.1/image/_python3.8/usr/lib/python3.8/site-packages/pyowm-3.1.1-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/pyowm-3.1.1::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
```