### PR TITLE
Fixed AirStatus parsing of Latitude and Longitude values from JSON

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Code
   * [ahertz](https://github.com/ahertz)
   * [alechewitt](https://github.com/alechewitt)
   * [camponez](https://github.com/camponez)
+  * [coreycoto](https://github.com/coreycoto)
   * [Darumin](https://github.com/Darumin)
   * [davidpirogov](https://github.com/davidpirogov)
   * [dev-iks](https://github.com/dev-iks)

--- a/pyowm/airpollutionapi30/airstatus.py
+++ b/pyowm/airpollutionapi30/airstatus.py
@@ -88,8 +88,8 @@ class AirStatus:
             raise exceptions.ParseAPIResponseError('Data is None')
         try:
             # -- location
-            lon = float(the_dict['coord']['lat'])
-            lat = float(the_dict['coord']['lon'])
+            lat = float(the_dict['coord']['lat'])
+            lon = float(the_dict['coord']['lon'])
             place = location.Location(None, lon, lat, None)
 
             # -- reception time (now)


### PR DESCRIPTION
The AirStatus class cannot parse longitude and latitude values for places like Seattle, where the longitude is greater than 90 or less than -90. 